### PR TITLE
Use "src" by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@harvest-profit/doc-flux-pdfs",
   "version": "1.0.5",
   "description": "pdfMake PDF parser for DocFlux",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "repository": "https://github.com/HarvestProfit/DocFlux-PDFs",
   "author": "Jake Humphrey <jake@harvestprofit.com>",
   "contributors": [],
@@ -41,7 +41,8 @@
   ],
   "files": [
     "README.md",
-    "dist"
+    "dist",
+    "src"
   ],
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/PDFDocument.js
+++ b/src/PDFDocument.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Document } from '@harvest-profit/doc-flux';
-import PdfMake from 'pdfmake/build/pdfmake';
-import PdfFonts from 'pdfmake/build/vfs_fonts';
+import * as PdfMake from 'pdfmake/build/pdfmake';
+import * as PdfFonts from 'pdfmake/build/vfs_fonts';
 import Parser from './Parser';
 
 import styles, { defaultStyles } from './styles';


### PR DESCRIPTION
Prevents some issues with newer versions of babel and webpack.